### PR TITLE
fix(ReactInstance): Removing async void Dispose behavior

### DIFF
--- a/ReactWindows/ReactNative/Bridge/ReactInstance.cs
+++ b/ReactWindows/ReactNative/Bridge/ReactInstance.cs
@@ -171,7 +171,7 @@ namespace ReactNative.Bridge
             });
         }
 
-        public async void Dispose()
+        public void Dispose()
         {
             DispatcherHelpers.AssertOnDispatcher();
 
@@ -183,11 +183,11 @@ namespace ReactNative.Bridge
             IsDisposed = true;
             _registry.NotifyReactInstanceDispose();
 
-            await QueueConfiguration.JavaScriptQueueThread.CallOnQueue(() =>
+            QueueConfiguration.JavaScriptQueueThread.CallOnQueue(() =>
             {
                 using (_bridge) { }
                 return true;
-            });
+            }).Wait();
 
             QueueConfiguration.Dispose();
 


### PR DESCRIPTION
When the dev manager reloads the bundle while the view hierarchy is updating, it may replace the root node in the middle of a view update dispatch operation. To prevent this from happening, the Dispose operation on the ReactInstance is now a blocking operation.

Fixes #266 - Root node collection modified while enumerating