### PR TITLE
fix(DevSupportManager): Remove timeout from bundle server HTTP client

### DIFF
--- a/ReactWindows/ReactNative/DevSupport/DevServerHelper.cs
+++ b/ReactWindows/ReactNative/DevSupport/DevServerHelper.cs
@@ -27,7 +27,6 @@ namespace ReactNative.DevSupport
         private const string PackagerStatusUrlFormat = "http://{0}/status";
         private const string PackagerOkStatus = "packager-status:running";
         private const int LongPollFailureDelayMs = 5000;
-        private const int HttpConnectTimeoutMs = 5000;
 
         private readonly DevInternalSettings _settings;
         private readonly HttpClient _client;
@@ -40,7 +39,6 @@ namespace ReactNative.DevSupport
         {
             _settings = settings;
             _client = new HttpClient();
-            _client.Timeout = TimeSpan.FromMilliseconds(HttpConnectTimeoutMs);
         }
 
         /// <summary>


### PR DESCRIPTION
The timeout on the bundle server connection is really only intended to be for connection time, not for HTTP response time (which can exceed 5 seconds if the file system is particularly slow). Removing the timeout logic altogether as there is no way to set connection timeouts in the current choice of HTTP client API.

Fixes #353 - Bundle server timeout is only meant for connection