### PR TITLE
fix(DevSupportManager): Progress dialog message corrected for debugging

### DIFF
--- a/ReactWindows/ReactNative/DevSupport/DevSupportManager.cs
+++ b/ReactWindows/ReactNative/DevSupport/DevSupportManager.cs
@@ -137,7 +137,11 @@ namespace ReactNative.DevSupport
 
             HideRedboxDialog();
 
-            var progressDialog = new ProgressDialog("Please wait...", "Fetching JavaScript bundle.");
+            var message = !_isUsingJsProxy 
+                ? "Fetching JavaScript bundle." 
+                : "Connecting to remote debugger.";
+
+            var progressDialog = new ProgressDialog("Please wait...", message);
             var dialogOperation = progressDialog.ShowAsync();
 
             if (_isUsingJsProxy)

--- a/ReactWindows/ReactNative/UIManager/ShadowNodeRegistry.cs
+++ b/ReactWindows/ReactNative/UIManager/ShadowNodeRegistry.cs
@@ -32,7 +32,7 @@ namespace ReactNative.UIManager
         /// <param name="node">The node.</param>
         public void AddRootNode(ReactShadowNode node)
         {
-           if (node == null)
+            if (node == null)
                 throw new ArgumentNullException(nameof(node));
 
             var tag = node.ReactTag;

--- a/ReactWindows/ReactNative/UIManager/ShadowNodeRegistry.cs
+++ b/ReactWindows/ReactNative/UIManager/ShadowNodeRegistry.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 
 namespace ReactNative.UIManager
 {
@@ -33,7 +32,7 @@ namespace ReactNative.UIManager
         /// <param name="node">The node.</param>
         public void AddRootNode(ReactShadowNode node)
         {
-            if (node == null)
+           if (node == null)
                 throw new ArgumentNullException(nameof(node));
 
             var tag = node.ReactTag;


### PR DESCRIPTION
The progress dialog for requests to the debug service was always related to "fetching the JS bundle", when sometimes the progress dialog represents waiting for connections to the Chrome debugger.

Fixes #310