### PR TITLE
fix(ReactScrollViewManager): Ensures responder is not attached on scroll event

### DIFF
--- a/ReactWindows/ReactNative/Views/Scroll/ReactScrollViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Scroll/ReactScrollViewManager.cs
@@ -396,6 +396,7 @@ namespace ReactNative.Views.Scroll
                         new JObject
                         {
                             { "target", reactTag },
+                            { "responderIgnoreScroll", true },
                             { "contentOffset", contentOffset },
                             { "contentInset", contentInset },
                             { "contentSize", contentSize },


### PR DESCRIPTION
Android and Windows share the same event sequence for scroll (topScrollBeginDrag -> topScroll -> topScrollEndDrag), and both require a native event flag 'responderIgnoreScroll'.

Fixes #327