### PR TITLE
fix(Timing): Fix behavior for `requestAnimationFrame`.

### DIFF
--- a/ReactWindows/ReactNative/Modules/Core/Timing.cs
+++ b/ReactWindows/ReactNative/Modules/Core/Timing.cs
@@ -110,7 +110,7 @@ namespace ReactNative.Modules.Core
             var scheduledTime = DateTimeOffset.FromUnixTimeMilliseconds((long)jsSchedulingTime);
             var initialTargetTime = (scheduledTime + period);
 
-            if (DateTimeOffset.Now > initialTargetTime && !repeat)
+            if (duration == 0 && !repeat)
             {
                 _jsTimersModule.callTimers(new[] { callbackId });
                 return;


### PR DESCRIPTION
Previously, the requestAnimationFrame callbacks occured on a tight loop.  Ensuring that only immediate timers callback instantly.

Fixes #394