### PR TITLE
Passing status code and reason to WebSocketModule.close on Windows

### DIFF
--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -109,7 +109,7 @@ class WebSocket extends EventTarget(WEBSOCKET_EVENTS) {
   }
 
   _close(code?: number, reason?: string): void {
-    if (Platform.OS === 'android') {
+    if (Platform.OS === 'android' || Platform.OS === 'windows') {
       // See https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
       var statusCode = typeof code === 'number' ? code : CLOSE_NORMAL;
       var closeReason = typeof reason === 'string' ? reason : '';


### PR DESCRIPTION
To reproduce the bug, just close websocket from JavaScript - it will crash on Win. This PR fixes that.