### PR TITLE
Sending WebSocket messages using Utf8

### DIFF
--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -109,7 +109,7 @@ class WebSocket extends EventTarget(WEBSOCKET_EVENTS) {
   }
 
   _close(code?: number, reason?: string): void {
-    if (Platform.OS === 'android') {
+    if (Platform.OS === 'android' || Platform.OS === 'windows') {
       // See https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
       var statusCode = typeof code === 'number' ? code : CLOSE_NORMAL;
       var closeReason = typeof reason === 'string' ? reason : '';

--- a/ReactWindows/ReactNative/Modules/WebSocket/WebSocketModule.cs
+++ b/ReactWindows/ReactNative/Modules/WebSocket/WebSocketModule.cs
@@ -36,6 +36,8 @@ namespace ReactNative.Modules.WebSocket
         {
             var webSocket = new MessageWebSocket();
 
+            webSocket.Control.MessageType = SocketMessageType.Utf8;
+
             if (protocols != null)
             {
                 foreach (var protocol in protocols)


### PR DESCRIPTION
**Background**

Trying to use Firebase. I noticed that sockets are connecting, and I always receive first message from the server, but after that server never replies to me.

Created my own Node.js WS server and I noticed that it never receives messages from app, instead it's receiving binary data. So Firebase probably does the same thing and ignores binary messages, even though they contain text.

**Discussion**

This change should make sure that all outgoing messages are sent as Utf8 messages as opposed to binary messages. It seems that binary messages are the default setting.