### PR TITLE
Fixes regression caused by #0f70801

### DIFF
--- a/ReactWindows/ReactNative/DevSupport/DevInternalSettings.cs
+++ b/ReactWindows/ReactNative/DevSupport/DevInternalSettings.cs
@@ -36,7 +36,7 @@ namespace ReactNative.DevSupport
 #if DEBUG
                 return GetSetting(JsDevModeDebugKey, true);
 #else
-                return GetSetting(JSDevModeDebugKey, false);
+                return GetSetting(JsDevModeDebugKey, false);
 #endif
             }
             set


### PR DESCRIPTION
Fixes a typo regression caused by https://github.com/ReactWindows/react-native/commit/0f708017cb7d2e21d56f2cdbf4f3edba4ddd1b60#diff-cf97ac74413f23ae8391e25fc59f7faeR40 which causes Release builds to fail.