### PR TITLE
fix(DevSupport): Prevent WebSocket JS Executor from hanging on reload

### DIFF
--- a/ReactWindows/ReactNative/DevSupport/DevSupportManager.cs
+++ b/ReactWindows/ReactNative/DevSupport/DevSupportManager.cs
@@ -382,9 +382,13 @@ namespace ReactNative.DevSupport
             try
             {
                 await _devServerHelper.LaunchDevToolsAsync(token);
-                var executor = new WebSocketJavaScriptExecutor();
-                await executor.ConnectAsync(_devServerHelper.WebsocketProxyUrl, token);
-                var factory = new Func<IJavaScriptExecutor>(() => executor);
+                var factory = new Func<IJavaScriptExecutor>(() =>
+                {
+                    var executor = new WebSocketJavaScriptExecutor();
+                    executor.ConnectAsync(_devServerHelper.WebsocketProxyUrl, token).Wait();
+                    return executor;
+                });
+
                 _reactInstanceCommandsHandler.OnReloadWithJavaScriptDebugger(factory);
                 dismissProgress();
             }


### PR DESCRIPTION
The WebSocket JS executor was being disconnected before before it was disposed because a new executor would replace it before the dispose operation. Ensuring the new connection only occurs after the previous connection has been disposed.

Fixes #374